### PR TITLE
Corrects spelling of available in rst

### DIFF
--- a/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/fsb/E3n6/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/fsb/E3n6/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/fsb/E3n6/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/fsb/E3n6/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/fsb/E3n6/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/fsb/E3n6/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/fsb/E3n6/runM1 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/fsb/E3n6/runM1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/fsb/E3n6/runM2 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/fsb/E3n6/runM2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/fsb/E3n6/runM3 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/fsb/E3n6/runM3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/fsb/E3n6/runM4 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/fsb/E3n6/runM4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM5/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM5/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/fsb/E3n6/runM5 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/fsb/E3n6/runM5>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM6/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/fsb/E3n6/runM6/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/fsb/E3n6/runM6 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/fsb/E3n6/runM6>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/nsb/E1n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/nsb/E1n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/nsb/E1n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/nsb/E1n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/nsb/E1n4/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/nsb/E1n4/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/nsb/E1n4/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/nsb/E1n4/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/nsb/E1n4/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/nsb/E1n4/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/nsb/E1n4/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/nsb/E1n4/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/nsb/E1n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/nsb/E1n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/nsb/E1n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/nsb/E1n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/nsb/E1n5/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/nsb/E1n5/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/nsb/E1n5/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/nsb/E1n5/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/nsb/E3n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/nsb/E3n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/nsb/E3n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/nsb/E3n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/nsb/E3n5/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/nsb/E3n5/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/nsb/E3n5/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/nsb/E3n5/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/nsb/E3n5/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/nsb/E3n5/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/nsb/E3n5/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/nsb/E3n5/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup90/nsb/E3n6/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup90/nsb/E3n6/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup90/nsb/E3n6/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup90/nsb/E3n6/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n4/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n4/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n4/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n4/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run1a/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run1a/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n5/run1a <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n5/run1a>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run1b/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run1b/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n5/run1b <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n5/run1b>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run1c/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run1c/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n5/run1c <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n5/run1c>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n5/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n5/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n5/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n5/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n5/run4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n5/run4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run5/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run5/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n5/run5 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n5/run5>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run6/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run6/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n5/run6 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n5/run6>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run7/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E1n5/run7/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E1n5/run7 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E1n5/run7>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E3n5/run1a/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E3n5/run1a/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E3n5/run1a <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E3n5/run1a>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E3n5/run1b/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E3n5/run1b/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E3n5/run1b <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E3n5/run1b>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E3n5/run1c/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E3n5/run1c/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E3n5/run1c <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E3n5/run1c>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E3n6/run1a/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n1/E3n6/run1a/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n1/E3n6/run1a <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n1/E3n6/run1a>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n4/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run01/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run01/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run01 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run01>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run02/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run02/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run02 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run02>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run03/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run03/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run03 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run03>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run04/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run04/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run04 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run04>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/run01/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/run01/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/run01 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/run01>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/run02/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/run02/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/run02 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/run02>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E1n6/runR4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n4/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run5/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run5/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run5 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run5>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run6/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run6/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run6 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run6>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run7/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run7/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run7 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n5/run7>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run01/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run01/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run01 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run01>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run02/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run02/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run02 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run02>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run03/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run03/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run03 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run03>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run04/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run04/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run04 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run04>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run05/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run05/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run05 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run05>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run5/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run5/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run5 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run5>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run6/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run6/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run6 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/run6>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/runM7/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/runM7/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/runM7 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/runM7>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/runM8/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/runM8/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/runM8 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type1/E3n6/runM8>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n4/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n4/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n4/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n4/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run1a/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run1a/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run1a <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run1a>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run1b/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run1b/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run1b <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run1b>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type4/E1n5/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n4/run1a/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n4/run1a/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n4/run1a <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n4/run1a>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n5/run1a/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n5/run1a/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n5/run1a <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n5/run1a>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n5/run1b/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n5/run1b/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n5/run1b <https://incite.geodynamics.org/DATA/mheimpel/Jup95/fsb/poly_n2/heating_type4/E3n5/run1b>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run1_Chktype1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run1_Chktype1/Case_doc.rst
@@ -18,7 +18,7 @@ The following parameters are used:
    :encoding: UTF-8
    :header-rows: 1
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/runM1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/runM1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/runM1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n5/10xRa/runM1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n5/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n5/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n5/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n5/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/run4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n5/run4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n5/run4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n5/run4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/4xRa/runM3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run1a/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run1a/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/run1a <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/run1a>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run1b/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run1b/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/run1b <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/run1b>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run1c/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run1c/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/run1c <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/run1c>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run1d/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run1d/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/run1d <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/run1d>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/run4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/run4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/run4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/runM1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/runM1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/runM2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/runM2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/runM3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/runM3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/runM4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/runM4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM5/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM5/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/runM5 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/runM5>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM6/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM6/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/runM6 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/runM6>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM7/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E1n6/runM7/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E1n6/runM7 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E1n6/runM7>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E2n6/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E2n6/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E2n6/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E2n6/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n5/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n5/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n5/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n5/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n5/run4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n5/run4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run5/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run5/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n5/run5 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n5/run5>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run6/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run6/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n5/run6 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n5/run6>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run7/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run7/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n5/run7 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n5/run7>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run8/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n5/run8/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n5/run8 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n5/run8>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM10/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM10/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM10 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM10>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM5/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM5/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM5 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM5>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM6/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM6/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM6 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM6>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM7/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM7/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM7 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM7>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM8/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM8/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM8 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM8>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM9/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM9/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM9 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/10xRa/runM9>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/Prp3/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/Prp3/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/Prp3/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/Prp3/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/nick_cetus_test/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/nick_cetus_test/Case_doc.rst
@@ -18,7 +18,7 @@ The following parameters are used:
    :encoding: UTF-8
    :header-rows: 1
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/run3 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/run4 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/run4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run5/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run5/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/run5 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/run5>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run6/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run6/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/run6 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/run6>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run7/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run7/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/run7 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/run7>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run8/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/run8/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/run8 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/run8>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/runM1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n6/runM1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n6/runM1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n6/runM1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n7/run1a/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n1/E3n7/run1a/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n1/E3n7/run1a <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n1/E3n7/run1a>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n2/E1n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n2/E1n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n2/E1n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n2/E1n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n2/E1n5/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n2/E1n5/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n2/E1n5/run2 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n2/E1n5/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n2/E3n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Jup95/nsb/poly_n2/E3n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Jup95/nsb/poly_n2/E3n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/Jup95/nsb/poly_n2/E3n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E1n3/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E1n3/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E1n3/run1 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E1n3/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E1n3/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E1n3/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E1n3/run2 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E1n3/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E1n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E1n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E1n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E1n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E1n4/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E1n4/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E1n4/run2 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E1n4/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E1n4/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E1n4/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E1n4/run3 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E1n4/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E1n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E1n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E1n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E1n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E3n5/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E3n5/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E3n5/run1 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E3n5/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E3n6/run1 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E3n6/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E3n6/run2 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E3n6/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E3n6/run3 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E3n6/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E3n6/run4 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E3n6/run4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run4a/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run4a/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E3n6/run4a <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E3n6/run4a>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run4b/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run4b/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E3n6/run4b <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E3n6/run4b>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run5/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run5/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E3n6/run5 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E3n6/run5>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run6/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/JupNatGeo/E3n6/run6/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/JupNatGeo/E3n6/run6 <https://incite.geodynamics.org/DATA/mheimpel/JupNatGeo/E3n6/run6>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/E1n3/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/E1n3/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/E1n3/run1 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/E1n3/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/E1n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/E1n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/E1n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/E1n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/E3n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/E3n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/E3n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/E3n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/E3n4/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/E3n4/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/E3n4/run2 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/E3n4/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/E3n4/run3/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/E3n4/run3/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/E3n4/run3 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/E3n4/run3>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/E3n4/run4/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/E3n4/run4/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/E3n4/run4 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/E3n4/run4>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/N5/E1n3/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/N5/E1n3/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/N5/E1n3/run1 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/N5/E1n3/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/N5/E1n3/run2/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/N5/E1n3/run2/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/N5/E1n3/run2 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/N5/E1n3/run2>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/N5/E1n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/N5/E1n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/N5/E1n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/N5/E1n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/mheimpel/Uranus75/N5/E3n4/run1/Case_doc.rst
+++ b/docs/source/INCITE/mheimpel/Uranus75/N5/E3n4/run1/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `mheimpel/Uranus75/N5/E3n4/run1 <https://incite.geodynamics.org/DATA/mheimpel/Uranus75/N5/E3n4/run1>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/ryadav/ensemble2/Pm0.05_Pr1_eta0.35_Ek1E-6_Ra2.5E10_no-slip_dyn/Case_doc.rst
+++ b/docs/source/INCITE/ryadav/ensemble2/Pm0.05_Pr1_eta0.35_Ek1E-6_Ra2.5E10_no-slip_dyn/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `ryadav/ensemble2/Pm0.05_Pr1_eta0.35_Ek1E-6_Ra2.5E10_no-slip_dyn <https://incite.geodynamics.org/DATA/ryadav/ensemble2/Pm0.05_Pr1_eta0.35_Ek1E-6_Ra2.5E10_no-slip_dyn>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/ryadav/ensemble2/Pm0.1_Pr1_eta0.35_Ek1E-6_Ra1E10_no-slip_dyn/Case_doc.rst
+++ b/docs/source/INCITE/ryadav/ensemble2/Pm0.1_Pr1_eta0.35_Ek1E-6_Ra1E10_no-slip_dyn/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `ryadav/ensemble2/Pm0.1_Pr1_eta0.35_Ek1E-6_Ra1E10_no-slip_dyn <https://incite.geodynamics.org/DATA/ryadav/ensemble2/Pm0.1_Pr1_eta0.35_Ek1E-6_Ra1E10_no-slip_dyn>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/ryadav/ensemble2/Pm0.2_Pr1_eta0.35_Ek1E-6_Ra5E9_no-slip_dyn/Case_doc.rst
+++ b/docs/source/INCITE/ryadav/ensemble2/Pm0.2_Pr1_eta0.35_Ek1E-6_Ra5E9_no-slip_dyn/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `ryadav/ensemble2/Pm0.2_Pr1_eta0.35_Ek1E-6_Ra5E9_no-slip_dyn <https://incite.geodynamics.org/DATA/ryadav/ensemble2/Pm0.2_Pr1_eta0.35_Ek1E-6_Ra5E9_no-slip_dyn>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/ryadav/ensemble3/Pm0.05_Pr0.1_eta0.35_Ek1E-6_Ra2.5E9_no-slip_dyn/Case_doc.rst
+++ b/docs/source/INCITE/ryadav/ensemble3/Pm0.05_Pr0.1_eta0.35_Ek1E-6_Ra2.5E9_no-slip_dyn/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `ryadav/ensemble3/Pm0.05_Pr0.1_eta0.35_Ek1E-6_Ra2.5E9_no-slip_dyn <https://incite.geodynamics.org/DATA/ryadav/ensemble3/Pm0.05_Pr0.1_eta0.35_Ek1E-6_Ra2.5E9_no-slip_dyn>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/ryadav/ensemble3/Pm0.5_Pr1_eta0.35_Ek1E-6_Ra3E9_no-slip_dyn/Case_doc.rst
+++ b/docs/source/INCITE/ryadav/ensemble3/Pm0.5_Pr1_eta0.35_Ek1E-6_Ra3E9_no-slip_dyn/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `ryadav/ensemble3/Pm0.5_Pr1_eta0.35_Ek1E-6_Ra3E9_no-slip_dyn <https://incite.geodynamics.org/DATA/ryadav/ensemble3/Pm0.5_Pr1_eta0.35_Ek1E-6_Ra3E9_no-slip_dyn>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/ryadav/ensemble3/Pm1_Pr1_eta0.35_Ek1E-6_Ra3E9_no-slip_dyn/Case_doc.rst
+++ b/docs/source/INCITE/ryadav/ensemble3/Pm1_Pr1_eta0.35_Ek1E-6_Ra3E9_no-slip_dyn/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `ryadav/ensemble3/Pm1_Pr1_eta0.35_Ek1E-6_Ra3E9_no-slip_dyn <https://incite.geodynamics.org/DATA/ryadav/ensemble3/Pm1_Pr1_eta0.35_Ek1E-6_Ra3E9_no-slip_dyn>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/ryadav/ensemble4/Pm0.03_Pr1_eta0.35_Ek1E-7_Ra3E11_no-slip_dyn/Case_doc.rst
+++ b/docs/source/INCITE/ryadav/ensemble4/Pm0.03_Pr1_eta0.35_Ek1E-7_Ra3E11_no-slip_dyn/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `ryadav/ensemble4/Pm0.03_Pr1_eta0.35_Ek1E-7_Ra3E11_no-slip_dyn <https://incite.geodynamics.org/DATA/ryadav/ensemble4/Pm0.03_Pr1_eta0.35_Ek1E-7_Ra3E11_no-slip_dyn>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/ryadav/ensemble4/Pm0.05_Pr1_eta0.35_Ek1E-7_Ra1.5E11_no-slip_dyn/Case_doc.rst
+++ b/docs/source/INCITE/ryadav/ensemble4/Pm0.05_Pr1_eta0.35_Ek1E-7_Ra1.5E11_no-slip_dyn/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `ryadav/ensemble4/Pm0.05_Pr1_eta0.35_Ek1E-7_Ra1.5E11_no-slip_dyn <https://incite.geodynamics.org/DATA/ryadav/ensemble4/Pm0.05_Pr1_eta0.35_Ek1E-7_Ra1.5E11_no-slip_dyn>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:

--- a/docs/source/INCITE/ryadav/ensemble4/Pm0.2_Pr1_eta0.35_Ek1E-7_Ra3E10_no-slip_dyn/Case_doc.rst
+++ b/docs/source/INCITE/ryadav/ensemble4/Pm0.2_Pr1_eta0.35_Ek1E-7_Ra3E10_no-slip_dyn/Case_doc.rst
@@ -9,7 +9,7 @@ Data is stored in the following directory:
 
 - `ryadav/ensemble4/Pm0.2_Pr1_eta0.35_Ek1E-7_Ra3E10_no-slip_dyn <https://incite.geodynamics.org/DATA/ryadav/ensemble4/Pm0.2_Pr1_eta0.35_Ek1E-7_Ra3E10_no-slip_dyn>`_
 
-Avaiable data.
+Available data.
 ==========================================
 
 The following data for analysis are aviable:


### PR DESCRIPTION
Available is misspelled in multiple Case_doc.rst files.  

This does a global replace in all .rst files. It does not change the misspelling in the current html or .txt files in the build directory.