### PR TITLE
Add configuration for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the root directory with Sphinx
+sphinx:
+  configuration: ./docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - html


### PR DESCRIPTION
This adds an experimental configuration to build the documentation on readthedocs. I will merge this to do some experiments on readthedocs. It may need fixes, but I need to merge it first to check if it works.